### PR TITLE
install.sh: create the `~/Applications/` dir if it doesn't exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,13 @@ if [ ! -d ~/Library/Services ]; then
     mkdir ~/Library/Services
 fi
 cp -r "Upload to YandexPhotos.workflow" ~/Library/Services/
+app_dir=~/Applications
+echo "Creating the user's applications folder (if doesn't exist yet)..."
+[[ -e "${app_dir}" ]] || mkdir -p "${app_dir}"
 echo "Copying authorizer to user's applications folder..."
-cp -r "YPU Authorizer.app" ~/Applications/
+cp -r "YPU Authorizer.app" "${app_dir}/"
 echo "Updating services cache..."
 /System/Library/CoreServices/pbs -flush
 echo "Updating Launch Services database"
-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -r "~/Applications/YPU Authorizer.app"
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -r "${app_dir}/YPU Authorizer.app"
 echo "Installation complete"


### PR DESCRIPTION
The user may not have the target applications directory yet. In that
case, the contents of the authorizer app would be copied inside
`~/Applications/` directory directly, which is wrong. The patch creates
the directory if doesn't exist yet.
